### PR TITLE
fix typo

### DIFF
--- a/nrf/applications/Aries/src/mqtt/mqtt.c
+++ b/nrf/applications/Aries/src/mqtt/mqtt.c
@@ -42,7 +42,7 @@ const uint8_t *pmqttBrokerHost = "a11homvea4zo8t-ats.iot.ap-east-1.amazonaws.com
 extern void mqttGetResponse(void);
 
 static void iotex_mqtt_get_topic(u8_t *buf, int len) {
-    snprintf(buf, len, "device/%s/%s/data",iotex_mqtt_get_client_id(), BACKEND_ID);
+    snprintf(buf, len, "device/%s/data",iotex_mqtt_get_client_id(), BACKEND_ID);
 }
 
 static void iotex_mqtt_get_firm_topic(u8_t *buf, int len) {


### PR DESCRIPTION
Can you please verify this pull request? I have not been able to test the compilation of the Pebble Tracker Firmware, since most of the links on the Pebble Tracker Firmware update documentation are broken, and information on how to merge the pebble-firmware-legacy with the applications like Gravel or Aries is missing, or poorly documented. 

If you have a working build system to check the Pebble Tracker Firmware, please try to test this fix. Currently the Aries application will fail, and does not send any data. Then it sometimes goes into the mode of "Please download config on the portal" mode, which cannot be interacted with.